### PR TITLE
Add debounce to live search

### DIFF
--- a/flex-grow.js
+++ b/flex-grow.js
@@ -1,0 +1,30 @@
+let flexSpec = require('./flex-spec')
+let Declaration = require('../declaration')
+
+class Flex extends Declaration {
+  /**
+   * Return property name by final spec
+   */
+  normalize() {
+    return 'flex'
+  }
+
+  /**
+   * Return flex property for 2009 and 2012 specs
+   */
+  prefixed(prop, prefix) {
+    let spec
+    ;[spec, prefix] = flexSpec(prefix)
+    if (spec === 2009) {
+      return prefix + 'box-flex'
+    }
+    if (spec === 2012) {
+      return prefix + 'flex-positive'
+    }
+    return super.prefixed(prop, prefix)
+  }
+}
+
+Flex.names = ['flex-grow', 'flex-positive']
+
+module.exports = Flex


### PR DESCRIPTION
Add a 300ms debounce to the live search input to reduce API calls and improving perceived performance under rapid typing. Uses lodash.debounce (extracted to a util) and updates the search component and tests to assert debounced behavior.